### PR TITLE
Support for nested objects

### DIFF
--- a/api_util.php
+++ b/api_util.php
@@ -71,7 +71,12 @@ class api_util {
     public static function phpToXml($key, $values) {
         $xml = "<" . $key . ">";
         foreach($values as $node => $value) {
-            $xml .= "<" . $node . ">" . htmlspecialchars($value) . "</" . $node . ">";
+            if (is_array($value)) {
+                $xml .= self::phpToXml($node,$value) ;
+            }
+            else {
+                $xml .= "<" . $node . ">" . htmlspecialchars($value) . "</" . $node . ">";
+            }
         }
         $xml .= "</" . $key . ">";
         return $xml;


### PR DESCRIPTION
This adds support for a nested set of values in an object.  Example would be a displaycontact in a customer.   phpToXml will traverse the nesting and produce a structured XML.
